### PR TITLE
Run the source generator post-initialization.

### DIFF
--- a/VeryUnsafe.SourceGeneration/DelegateToActionSourceGenerator.cs
+++ b/VeryUnsafe.SourceGeneration/DelegateToActionSourceGenerator.cs
@@ -13,11 +13,13 @@ public class DelegateToActionSourceGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterPostInitializationOutput(ctx =>
-        {
-            var methodsSource = GenerateMethods();
-            ctx.AddSource($"{veryUnsafeName}.Delegates.g.cs", methodsSource);
-        });
+        context.RegisterPostInitializationOutput(Generate);
+    }
+
+    private void Generate(IncrementalGeneratorPostInitializationContext postInitializationContext)
+    {
+        var methodsSource = GenerateMethods();
+        postInitializationContext.AddSource($"{veryUnsafeName}.Delegates.g.cs", methodsSource);
     }
 
     private static string GenerateMethods()

--- a/VeryUnsafe.SourceGeneration/DelegateToActionSourceGenerator.cs
+++ b/VeryUnsafe.SourceGeneration/DelegateToActionSourceGenerator.cs
@@ -13,16 +13,14 @@ public class DelegateToActionSourceGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterImplementationSourceOutput(context.CompilationProvider, Generate);
+        context.RegisterPostInitializationOutput(ctx =>
+        {
+            var methodsSource = GenerateMethods();
+            ctx.AddSource($"{veryUnsafeName}.Delegates.g.cs", methodsSource);
+        });
     }
 
-    private void Generate(SourceProductionContext sourceProductionContext, Compilation compilation)
-    {
-        var methodsSource = GenerateMethods();
-        sourceProductionContext.AddSource($"{veryUnsafeName}.Delegates.g.cs", methodsSource);
-    }
-
-    private string GenerateMethods()
+    private static string GenerateMethods()
     {
         const string header =
 $@"


### PR DESCRIPTION
Unless I'm missing something, since the source generator's output is fixed and does not depend on the compilation, emitting it in a post-initialization context would be more efficient.